### PR TITLE
Adds LitServe and LitGPT to the list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The LLM space is complicated! This repo provides a curated list to help you navi
 
 - [Transformers](https://huggingface.co/docs/transformers/en/installation) - Hugging Face Transformers is a popular library for Natural Language Processing (NLP) tasks, including fine-tuning large language models.
 - [Unsloth](https://github.com/unslothai/unsloth) - Finetune Llama 3.2, Mistral, Phi-3.5 & Gemma 2-5x faster with 80% less memory!
+- [litgpt](https://github.com/Lightning-AI/litgpt) - 20+ high-performance LLMs with recipes to fine-tune, pretrain and deploy at scale.
 
 ## Serving
 
@@ -63,6 +64,7 @@ The LLM space is complicated! This repo provides a curated list to help you navi
 
 - [sglang](https://github.com/sgl-project/sglang) - SGLang is a fast serving framework for large language models and vision language models.
 
+- [LitServe](https://github.com/Lightning-AI/LitServe) - LitServe is a lightning-fast serving engine for any AI model of any size. Flexible. Easy. Enterprise-scale.
 
 ## Datasets
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The LLM space is complicated! This repo provides a curated list to help you navi
 
 - [Transformers](https://huggingface.co/docs/transformers/en/installation) - Hugging Face Transformers is a popular library for Natural Language Processing (NLP) tasks, including fine-tuning large language models.
 - [Unsloth](https://github.com/unslothai/unsloth) - Finetune Llama 3.2, Mistral, Phi-3.5 & Gemma 2-5x faster with 80% less memory!
-- [litgpt](https://github.com/Lightning-AI/litgpt) - 20+ high-performance LLMs with recipes to fine-tune, pretrain and deploy at scale.
+- [LitGPT](https://github.com/Lightning-AI/litgpt) - 20+ high-performance LLMs with recipes to pretrain, finetune, and deploy at scale.
 
 ## Serving
 


### PR DESCRIPTION
**Adds LitServe and LitGPT to the list.**

LitServe and LitGPT are open-source libraries developed by Lightning AI.

- **[LitServe](https://github.com/Lightning-AI/lit-serve)**: A flexible and easy-to-use serving engine for AI models, supporting both large language models (LLMs) and non-LLMs.
- **[LitGPT](https://github.com/Lightning-AI/lit-gpt)**: A suite of over 20 high-performance LLMs, complete with tools and recipes for pretraining, fine-tuning, and deploying at scale.